### PR TITLE
fix: avoid counting invalid guess

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -59,21 +59,24 @@
 
     function checkGuess() {
       const guess = parseInt(document.getElementById("guessInput").value);
-      attempts++;
 
       if (isNaN(guess)) {
         document.getElementById("message").textContent = "Please enter a valid number.";
         return;
       }
 
+      attempts++;
+
       if (guess === secretNumber) {
         document.getElementById("message").textContent = `🎉 Correct! The number was ${secretNumber}.`;
-        document.getElementById("attempts").textContent = `Attempts: ${attempts}`;
       } else if (guess < secretNumber) {
         document.getElementById("message").textContent = "Too low! Try again.";
       } else {
         document.getElementById("message").textContent = "Too high! Try again.";
       }
+
+      document.getElementById("attempts").textContent = `Attempts: ${attempts}`;
+      document.getElementById("guessInput").value = "";
     }
 
     function resetGame() {


### PR DESCRIPTION
## Summary
- prevent invalid inputs from counting toward total attempts
- show the updated attempt count and clear guess input after each guess

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c2ec786c83329223415badb31adc